### PR TITLE
Fix problem setting the querydict object

### DIFF
--- a/crits/core/api.py
+++ b/crits/core/api.py
@@ -519,7 +519,7 @@ class CRITsAPIResource(MongoEngineResource):
                             if op == '$eq':
                                 querydict[field] = remove_quotes(val)
                             else:
-                                querydict[field] = {op: remove_quotes(val)}
+                                querydict[field] = {op: val}
                 elif field in ('size', 'schema_version'):
                     querydict[field] = v_int
                 elif field in ('created', 'modified'):


### PR DESCRIPTION
On line 522 of this module, a previous edit added the "remove_quotes" function around the val variable. I reverted this code to the way it was done before support for $eq was added - the val variable in many cases is a list which causes the remove_quotes function to fail.  When it is a list, the quotes have already been removed